### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@
   - **简介**： 这本书简称 `CSAPP`，是所有计算机人士必看的一本「**内功心法**」，也是名校卡耐基·梅隆大学的计算机专业本科生的基础教程，常看常新，在海内外享誉无数。
   - **中文版**：[《深入理解计算机系统》](https://cloud.189.cn/t/iEn2MfQZVvMv) 第三版 (2016) 【`美版中译本` | `高清扫描版` | `彩色版`】
 
+- [Computer Organization and Design RISC-V Edition The Hardware/Software Interface](https://www.aliyundrive.com/s/Rscs2rGkNhG) 2nd Edition (2021)【`美版`】
+  - **简介**：计算机组成与设计：硬件/软件接口系列的书是两位泰斗级人物： David A. Patterson 和 John L. Hennessy 合著的巨作，著名的《计算机体系结构：量化研究方法》也是他们的作品。
+  - **中文版**：[《计算机组成与设计：硬件/软件接口 MIPS版》](https://cloud.189.cn/t/INrQ7vnQnaum) 第五版 (2015) 【`高清扫描版`】
+
 - [Compilers: Principles, Techniques, and Tools](https://www.aliyundrive.com/s/swx2pdvczph) 2nd Edition International Edition (2014) 【`国际版`】
   - **简介**：这就是大名鼎鼎的编译原理「恐龙书」或「龙书」，另有「虎书」、「鲸书」，但是三本书中唯有龙书最牛
   - **中文版**：[《编译原理》](https://cloud.189.cn/t/MNBzmynaaiAb) 【`美版中译本` | `高清扫描版`】
@@ -64,10 +68,6 @@
 - [Modern Operation Systems](https://cloud.189.cn/t/emIvMr3EBvaq) 4th Edition (2015) 【`美版`】
   - **简介**：这本书的作者是著名的计算机科学家 Tanenbaum，作者名字一般译为**塔嫩鲍姆**，他也是著名的 MINIX 系统的作者。Linux 内核的作者 Linus Torvalds 在他的自传 Just for Fun 里面这样评价塔嫩鲍姆的另一本书：**每个人都会遇到一本改变自己一生的书吧......而安德鲁·坦尼鲍姆所著的书《操作系统：设计与实现》让我脱胎换骨，达到了一个全新的高度，改变了我的一生。** 这本《现代操作系统》更具现代意义，算是 Linus 高度赞誉的那本书的新时代版本。如果你能把这本书通读一遍，相信你肯定可以升华自己的境界。
   - **中文版**：[《现代操作系统》](https://cloud.189.cn/t/fi2MJjMnUZFb) 第四版 (2017) 【`高清扫描版`】
-
-- [Computer Organization and Design RISC-V Edition The Hardware/Software Interface](https://www.aliyundrive.com/s/Rscs2rGkNhG) 2nd Edition (2021)【`美版`】
-  - **简介**：计算机组成与设计：硬件/软件接口系列的书是两位泰斗级人物： David A. Patterson 和 John L. Hennessy 合著的巨作，著名的《计算机体系结构：量化研究方法》也是他们的作品。
-  - **中文版**：[《计算机组成与设计：硬件/软件接口 MIPS版》](https://cloud.189.cn/t/INrQ7vnQnaum) 第五版 (2015) 【`高清扫描版`】
 
 - [Computer Networking: A Top-Down Approach](https://www.aliyundrive.com/s/zZvJzm9QN5U) 8th Edition (2021) 【`美版`】
   - **简介**：这是计算机网络经典教材，采用自顶向下方法写作，适合大多数人。

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
   - **简介**：**离散数学**笼统地介绍了许多与计算机相关的数学领域，离散数学并不是「连续数学」即分析学的对立面，而是一个大杂烩，里面什么都有，排序、图论、自动机理论、编码、逻辑等等都被囊括其中。
   - **中文版**：[《离散数学及其应用》](https://cloud.189.cn/t/yUjaAjMNnqIf) 第七版 (2015) 【`高清扫描版`】
 
+- [Linear Algebra and Its Applications]() 6th Edition Global Edition (2022) 【`国际版`】
+
 - [Operations Research: An Introduction](https://www.aliyundrive.com/s/WDDoLBMX3aW) 10th Edition (2017) 【`国际版` | `黑白版`】
   - **简介**：运筹学是一个涉及过程优化的学问，在数学里是一个大的分支，网络流问题是该领域的研究核心，因为诸如指派、线性规划、整数规划、零一规划、拓扑图问题等，都可以全部或者部分地归为网络流问题。这个领域的问题以及结论非常多，建议非此专业的新手，把这门课当作算法课的补充与延伸，不要过于深入。
   - **中文版**：**暂无**
@@ -59,7 +61,7 @@
 
 - [Compilers: Principles, Techniques, and Tools](https://www.aliyundrive.com/s/swx2pdvczph) 2nd Edition International Edition (2014) 【`国际版`】
   - **简介**：这就是大名鼎鼎的编译原理「恐龙书」或「龙书」，另有「虎书」、「鲸书」，但是三本书中唯有龙书最牛
-  - **中文版**：[《编译原理》](https://cloud.189.cn/t/MNBzmynaaiAb) 【`美版中译本` | `高清扫描版`】
+  - **中文版**：[《编译原理》](https://cloud.189.cn/t/MNBzmynaaiAb) (2009) 【`美版中译本` | `高清扫描版`】
 
 - [Operating System Concepts](https://www.aliyundrive.com/s/SCejGWuZsVQ) 10th Edition (2018) 【`美版`】
   - **简介**：操作系统有很多的经典教材，这本书是其中之一。但是这本书正如其名字所示，着重于概念，对于一些细节和举例，并不是很详细。
@@ -69,7 +71,7 @@
   - **简介**：这本书的作者是著名的计算机科学家 Tanenbaum，作者名字一般译为**塔嫩鲍姆**，他也是著名的 MINIX 系统的作者。Linux 内核的作者 Linus Torvalds 在他的自传 Just for Fun 里面这样评价塔嫩鲍姆的另一本书：**每个人都会遇到一本改变自己一生的书吧......而安德鲁·坦尼鲍姆所著的书《操作系统：设计与实现》让我脱胎换骨，达到了一个全新的高度，改变了我的一生。** 这本《现代操作系统》更具现代意义，算是 Linus 高度赞誉的那本书的新时代版本。如果你能把这本书通读一遍，相信你肯定可以升华自己的境界。
   - **中文版**：[《现代操作系统》](https://cloud.189.cn/t/fi2MJjMnUZFb) 第四版 (2017) 【`高清扫描版`】
 
-- [Computer Networking: A Top-Down Approach](https://www.aliyundrive.com/s/zZvJzm9QN5U) 8th Edition (2021) 【`美版`】
+- [Computer Networking: A Top-Down Approach](https://www.aliyundrive.com/s/HCD5LTX2Ajd) 8th Edition (2021) 【`美版`】【`国际版`】
   - **简介**：这是计算机网络经典教材，采用自顶向下方法写作，适合大多数人。
   - **中文版**：[《计算机网络：自顶向下方法》](https://cloud.189.cn/t/mIzY7rmiUnua) 第七版 (2018) 【`高清扫描版`】
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 
 ## 1. 电子书
 
-该目录给出了某些电子书的下载链接，他们是**从互联网下载到的**计算机经典教材.。
+该目录整理了在互联网上**可下载的**的计算机经典教材。
 
-`P.S.` URL 里的中文版教材大多数是经典英文教材的**中译本**，由于是扫描版，所以体积较大。我们尽可能地将这些**原版/高清扫描版**添加**电子书签**，并进行 `OCR` 处理，方便学习。
+`P.S.` 中文版教材大多数是原文教材**中译本**的扫描版，所以体积较大。我们将尽可能地将这些书添加**书签**，并进行 `OCR` 处理，方便读者学习。
 
 **如果有任何侵权行为，请及时联系我们的 contributor 进行处理**。
 
-这里提供的教材都是入门教程，诸如高级计算机体系结构、高级网络调优、高级编译原理等类教材，暂不过多提供。
+这里提供的教材都是入门教程，诸如高级计算机体系结构、高级网络调优、高级编译原理等内容的教材，暂不过多提供。
 
 ### 1.1 下载说明 📖
 
-为避免版权问题，我们仅提供下载链接。
+为了避免版权问题，这里仅提供下载链接。
 
-本库会尽量避免提供下载速度非常慢的**百度网盘**下载链接，目前速度非常好的是**天翼云**，所以给出的下载链接基本都是天翼云的**永久无密码链接**，需注册天翼账号并登录，然后直接点击下载。
+本库会尽量避免提供下载速度非常慢的**百度网盘**下载链接，目前速度非常好的是**天翼云盘**和**阿里云盘**，都需要注册并登录账号后下载。大部分原版教材提供的是**阿里云盘**的链接，中文教材提供的是**天翼云盘**的链接，所有下载链接基本都是**永久无密码链接**。
 
 如果遇到以下问题，请直接提 `Issue` 进行反馈。
 
@@ -31,85 +31,87 @@
 
 本目录会逐渐完善充实，有需要其他书籍但找不到的朋友，可以提请求，让大家帮你找。
 
-> **重要提醒**：下面的链接及其简介中，标题中的超链接是该书的**原版链接**，翻译版将会在`该书中文版`字段中给出。
+> **重要提醒**：下面的链接及其简介中，标题中的超链接是该书的**原版链接**，中译版将会在`中文版`字段中给出。如不特殊声明标签内容，原版教材分为两种：【`美版`】和【`国际版`】，标签均默认为【`非扫描版` | `有书签` | `彩色版`】，中文版教材默认标签为对应美版和国际版的翻译版，默认为【`扫描版` | `OCR` | `有书签` | `黑白版`】。
 
 #### 1.2.1 数学基础
 
-- [Discrete Mathematics and Its Applications](https://cloud.189.cn/t/7FVVBzyY7Zry) 【`英文原版` | `彩色版` | `带书签` | `English`】
+- [Discrete Mathematics and Its Applications](TODO) 8th Edition (2021) 【`美版`】
   - **简介**：**离散数学**笼统地介绍了许多与计算机相关的数学领域，离散数学并不是「连续数学」即分析学的对立面，而是一个大杂烩，里面什么都有，排序、图论、自动机理论、编码、逻辑等等都被囊括其中。
-  - **该书中文版**：[《离散数学及其应用》](https://cloud.189.cn/t/yUjaAjMNnqIf) 【`OCR` | `带书签` | `高清扫描`】
+  - **中文版**：[《离散数学及其应用》](https://cloud.189.cn/t/yUjaAjMNnqIf) 第七版 (2015) 【`高清扫描版`】
 
-- [Operations Research: Applications And Algorithms](https://cloud.189.cn/t/BR7FJvymEzIb) 【`英文原版` | `彩色版` | `带书签` | `English`】
+- [Operations Research: An Introduction](https://cloud.189.cn/t/BR7FJvymEzIb) 10th Edition (2017) 【`国际版` | `黑白版`】
   - **简介**：运筹学是一个涉及过程优化的学问，在数学里是一个大的分支，网络流问题是该领域的研究核心，因为诸如指派、线性规划、整数规划、零一规划、拓扑图问题等，都可以全部或者部分地归为网络流问题。这个领域的问题以及结论非常多，建议非此专业的新手，把这门课当作算法课的补充与延伸，不要过于深入。
-  - **该书中文版**：**无中文版**
+  - **中文版**：**暂无**
 
-- [Computational Complexity: A Modern Approach](https://cloud.189.cn/t/mY7RrqAf6RVf) 【`英文原版` | `无书签` | `English`】
+- [Computational Complexity: A Modern Approach](TODO) (2009) 【`美版` | `黑白版`】
   - **简介**：可计算理论、计算复杂性理论应该是现代计算机的核心思想，这是阿兰·图灵和丘奇的开创性理论及拓展，学习本门课需要比较强的数学基础，但是这门课不一定是入门者必学的课，但是学了这门课之后，你会对计算机的原理将有更深刻的认视，比如 CPU 为什么需要寄存器，为什么有些问题是不可计算的，为什么计算安全性也能用于实际。由于本门课一般是研究生课程，而且实际应用中的作用不明显，所以不把这门课放在数学基础篇的开头。这本书的作者是著名的计算科学专家阿罗拉。
-  - **该书中文版**：[《计算复杂性：现代方法》](https://cloud.189.cn/t/FnYZBnmANN3m)
+  - **中文版**：[《计算复杂性：现代方法》](https://cloud.189.cn/t/FnYZBnmANN3m) (2012) 【`高清扫描版`】
 
 #### 1.2.2 计算机基础
 
-- [Computer Systems: A Programmer's Perspective](https://cloud.189.cn/t/RfA3uaauEjim) 【`非英文原版` | `彩色版` | `带书签` | `English`】
-  - **简介**： 这本书简称 `CSAPP`，是所有入行计算机的人必看的一本「**内功心法**」，也是名校卡耐基·梅隆大学的计算机专业本科生基础教程，常看常新，海内外享誉无数。这本英文彩色版有点问题，不是原版，建议看中文版，对照英文。
-  - **该书中文版**：[《深入理解计算机系统》](https://cloud.189.cn/t/iEn2MfQZVvMv)【`OCR` ｜ `带书签` | `高清扫描` | `彩色版`】
+- [Computer Systems: A Programmer's Perspective](TODO) 3rd Edition (2015) 【`国际版`】
+  - **简介**： 这本书简称 `CSAPP`，是所有计算机人士必看的一本「**内功心法**」，也是名校卡耐基·梅隆大学的计算机专业本科生的基础教程，常看常新，在海内外享誉无数。
+  - **中文版**：[《深入理解计算机系统》](https://cloud.189.cn/t/iEn2MfQZVvMv) 第三版 (2016) 【`美版中译本` | `高清扫描版` | `彩色版`】
 
-- [Computer Networking: A Top-Down Approach](https://cloud.189.cn/t/ree6zaBnYje2) 【`英文扫描版` | `彩色版` | `带凌乱书签` | `English`】
-  - **简介**：这是计算机网络经典教材，采用自顶向下方法写作，适合大多数人。由于这本书还没有开放授权，所以只能找到一个不太清楚的 PDF 英文版，不过该书的中文版很清楚，也有完美书签。另外，该书的[第六版](https://www.jianguoyun.com/p/DZDtkw0Qw8vpBxjd9b8C)已经开放下载，是英文原版，不介意的新手，可以参阅第六版英文版。
-  - **该书中文版**：[《计算机网络：自顶向下方法》](https://cloud.189.cn/t/mIzY7rmiUnua) 【`OCR` ｜ `带书签` | `高清扫描`】
+- [Computer Networking: A Top-Down Approach](TODO) 8th Edition (2021) 【`美版`】
+  - **简介**：这是计算机网络经典教材，采用自顶向下方法写作，适合大多数人。
+  - **中文版**：[《计算机网络：自顶向下方法》](https://cloud.189.cn/t/mIzY7rmiUnua) 第七版 (2018) 【`高清扫描版`】
 
-- [Computer Networks: A Systems Approach](https://cloud.189.cn/t/yaaMraEfMrYb) 【`英文原版` | `彩色版` | `带书签` | `English`】
+Compilers Principles, Techniques, and Tools
+
+- [Computer Networks: A Systems Approach](TODO) 6th Edition (2021) 【`美版`】
   - **简介**：该书与《计算机网络：自顶向下方法》齐名，该书的顺序是自底向上，但是没有花费过多的笔墨介绍物理层。该书对于链路层、网络层、高级网络层、端到端（传输层）的介绍非常详细，可以有助于网络学习者快速建立全局观，而且可以避免沉迷在纷繁的应用层协议里无法自拔。推荐初学者先看这本书。
-  - **该书中文版**：[《计算机网络：系统方法》](https://cloud.189.cn/t/QbAbainaE3Yb) 【`OCR` ｜ `带书签` | `高清扫描`】
+  - **中文版**：[《计算机网络：系统方法》](https://cloud.189.cn/t/QbAbainaE3Yb) 第五版 (2015) 【`高清扫描版`】
 
-- [Compilers: Principles, Techniques, and Tools](https://cloud.189.cn/t/nEFVzmR36fm2) 【`OCR` ｜ `带书签` | `高清扫描` | `English`】
+- [Compilers: Principles, Techniques, and Tools](TODO) 2nd Edition (2014) 【`国际版`】
   - **简介**：这就是大名鼎鼎的编译原理「恐龙书」或「龙书」，另有「虎书」、「鲸书」，但是三本书中唯有龙书最牛
-  - **该书中文版**：[《编译原理》](https://cloud.189.cn/t/MNBzmynaaiAb) 【`OCR` ｜ `带书签` | `高清扫描`】
+  - **中文版**：[《编译原理》](https://cloud.189.cn/t/MNBzmynaaiAb) 【`美版中译本` | `高清扫描版`】
 
-- [Operating System Concepts](https://cloud.189.cn/t/muiuAfmMbq2i) 【`英文原版` | `彩色版` | `带书签` | `English`】
+- [Operating System Concepts](TODO) 10th Edition (2018) 【`美版`】
   - **简介**：操作系统有很多的经典教材，这本书是其中之一。但是这本书正如其名字所示，着重于概念，对于一些细节和举例，并不是很详细。
-  - **该书中文版**：[《操作系统概念》](https://cloud.189.cn/t/ruqqArzUfqYb) 【`OCR` ｜ `带书签` | `高清扫描`】
+  - **中文版**：[《操作系统概念》](https://cloud.189.cn/t/ruqqArzUfqYb) 第九版 (2018) 【`高清扫描版`】
 
-- [Modern Operation Systems](https://cloud.189.cn/t/emIvMr3EBvaq) 【`英文原版` | `彩色版` | `带书签` | `English`】
-  - **简介**：这本书的作者是著名的计算机科学家 Tanenbaum，作者名字一般译为**塔嫩鲍姆**，他也是著名的 MINIX 系统的作者。Linux 内核的作者 Linus Torvalds 在他的自传 Just for Fun 里面这样评价塔嫩鲍姆的另一本书：**每个人都会遇到一本改变自己一生的书吧......而安德鲁•坦尼鲍姆所著的书《操作系统：设计与实现》让我脱胎换骨，达到了一个全新的高度，改变了我的一生。** 这本《现代操作系统》更具现代意义，算是 Linus 高度赞誉的那本书的新时代版本。如果你能把这本书通读一遍，相信你肯定可以升华自己的境界。
-  - **该书中文版**：[《现代操作系统》](https://cloud.189.cn/t/fi2MJjMnUZFb) 【`OCR` ｜ `带书签` | `高清扫描`】
+- [Modern Operation Systems](https://cloud.189.cn/t/emIvMr3EBvaq) 4th Edition (2015) 【`美版`】
+  - **简介**：这本书的作者是著名的计算机科学家 Tanenbaum，作者名字一般译为**塔嫩鲍姆**，他也是著名的 MINIX 系统的作者。Linux 内核的作者 Linus Torvalds 在他的自传 Just for Fun 里面这样评价塔嫩鲍姆的另一本书：**每个人都会遇到一本改变自己一生的书吧......而安德鲁·坦尼鲍姆所著的书《操作系统：设计与实现》让我脱胎换骨，达到了一个全新的高度，改变了我的一生。** 这本《现代操作系统》更具现代意义，算是 Linus 高度赞誉的那本书的新时代版本。如果你能把这本书通读一遍，相信你肯定可以升华自己的境界。
+  - **中文版**：[《现代操作系统》](https://cloud.189.cn/t/fi2MJjMnUZFb) 第四版 (2017) 【`高清扫描版`】
 
 #### 1.2.3 算法基础
 
-- [Algorithms](https://cloud.189.cn/t/uIbQRbniQNrm) 【`英文原版` | `彩色版` | `带书签` | `English`】
-  - **简介**：这本就是大名鼎鼎的「**算法4**」，这本书比《算法导论》简单点，但是学起来更顺手。
-  - **该书中文版**：[《算法》](https://cloud.189.cn/t/RBvIvurEFNZn) 【`OCR` ｜ `带书签` | `高清扫描`】
+- [Algorithms](https://cloud.189.cn/t/uIbQRbniQNrm) 4th Edition (2014) 【`美版`】
+  - **简介**：这本就是大名鼎鼎的「**算法4**」，这本书起点比《算法导论》低，学起来更容易。
+  - **中文版**：[《算法》](TODO) 【`非扫描版` | `彩色版`】
 
-- [Introduction to Algorithms](https://cloud.189.cn/t/FbiuIfNZjMFr) 【`英文原版` | `彩色版` | `带书签` | `English`】
+- [Introduction to Algorithms](TODO) 4th Edition (2022) 【`美版`】
   - **简介**：算法导论是算法学习者必备的一本书，内容深度、广度都很大，是进阶选手、基础比较高的学习者所必看的一本算法书。该书给出的都是伪代码，因此比较适合理解原理。
-  - **该书中文版**：[《算法导论》](https://cloud.189.cn/t/iuqm2aVvemem) 【`OCR` ｜ `带书签` | `高清扫描`】
+  - **中文版**：[《算法导论》](https://cloud.189.cn/t/iuqm2aVvemem) 第三版 (2012) 【`高清扫描版`】
 
-- [Computer Organization and Design: The Hardware/Software Interface](https://cloud.189.cn/t/J3YR7nmaAzim) 【`英文原版` | `彩色版` | `带书签` | `English`】
-  - **简介**：这本书是**计算机原理**界的大牛 Patterson, David A. 的著作，此人是计算机原理界的大佬，更是计算机体系结构（也就是 CPU 原理）的执牛耳者，著名的《计算机体系结构：量化研究方法》也是他的作品。
-  - **该书中文版**：[《计算机组成与设计：硬件/软件接口》](https://cloud.189.cn/t/INrQ7vnQnaum) 【`OCR` ｜ `带书签` | `高清扫描`】
+- [Computer Organization and Design: The Hardware/Software Interface](TODO) RISC-V Edition 2nd Edition (2021)【`美版`】
+  - **简介**：此系列的书是两位泰斗级人物： David A. Patterson 和 John L. Hennessy 合著的巨作，著名的《计算机体系结构：量化研究方法》也是他们的作品。
+  - **中文版**：[《计算机组成与设计：硬件/软件接口》](https://cloud.189.cn/t/INrQ7vnQnaum) MIPS 版 第五版 (2015) 【`高清扫描版`】
 
 #### 1.2.4 UNIX & Linux
 
-- [Linux Kernel Development](https://cloud.189.cn/t/JvymayYjiE7n) 【`英文原版` | `彩色版` | `带书签` | `English`】
+- [Linux Kernel Development](https://cloud.189.cn/t/JvymayYjiE7n) 3rd Edition (2010)【`美版`】
   - **简介**：内核开发比较硬，可以参阅。
-  - **该书中文版**：[《Linux 内核设计与实现》](https://cloud.189.cn/t/y6jENruEbEzm) 【`OCR` ｜ `带书签` | `次高清扫描`】
+  - **中文版**：[《Linux 内核设计与实现》](https://cloud.189.cn/t/y6jENruEbEzm) 第三版 (2011) 【`次高清扫描版`】
 
-- [Harley Hahn's Guide to Unix and Linux](https://cloud.189.cn/t/6jqErmBVvARr) 【`英文原版` | `彩色版` | `带书签` | `English`】
+- [Harley Hahn's Guide to Unix and Linux](https://cloud.189.cn/t/6jqErmBVvARr)  (2008) 【`美版`】
   - **简介**：这本书的作者哈雷·哈恩以幽默风趣的口吻讲述了 UNIX / Linux 的前世今生以及常用命令的由来、用法，这本书是入门 UNIX 世界的必读之书，假如你是一个对 UNIX 世界一无所知，只会用 Windows 的小白，那么这本书极其适合你。可惜的是，这本书的中文版绝版了；本书中文版被命名为 《Unix & Linux 大学教程》，实在让人摸不着头脑。
-  - **该书中文版**：[《Unix & Linux 大学教程》](https://cloud.189.cn/t/MNZr6jB3QRBv) 【`OCR` ｜ `带书签` | `次高清扫描`】
+  - **中文版**：[《Unix & Linux 大学教程》](https://cloud.189.cn/t/MNZr6jB3QRBv) (2010) 【`次高清扫描版`】
 
-- [Advanced Programming in the UNIX Environment](https://cloud.189.cn/t/veyiQfYVV7Rj) 【`英文原版` | `彩色版` | `带书签` | `English`】
+- [Advanced Programming in the UNIX Environment](https://cloud.189.cn/t/veyiQfYVV7Rj) 3rd Edtion (2013) 【`美版`】
   - **简介**：UNIX 环境是绝大多数计算机从业者绕不开的，如果说 Harley Hahn's Guide to Unix and Linux 是入门者的有趣教程，那么这本书就是深入了解 UNIX 的一本必备之书。这本书作为 UNIX 的先驱 Stevens 的代表作，其价值不可估量。
-  - **该书中文版**：[《Unix 环境高级编程》](https://cloud.189.cn/t/j2uAFjRZnQny) 【`OCR` ｜ `带书签` | `高清扫描`】
+  - **中文版**：[《Unix 环境高级编程》](https://cloud.189.cn/t/j2uAFjRZnQny) 第三版 (2014) 【`高清扫描版`】
 
 #### 1.2.5 数据库
 
-- [Database_System_Concepts](https://cloud.189.cn/t/eAviaifuqqIf) 【`英文原版` | `彩色版`】
+- [Database System Concepts](TODO) 7th Edition (2020) 【`美版`】
   - **简介**: 《数据库系统概念》是国外的经典数据库教材，里面关于并发，事务，锁等有细致系统的讲解。
-  - **该书中文版** [《数据库系统概念》](https://cloud.189.cn/t/b6vUFvmmyi2u)
+  - **中文版** [《数据库系统概念》](https://cloud.189.cn/t/b6vUFvmmyi2u) 第六版 (2012) 【`高清扫描版`】
 
 ### 1.3 一键下载上述所有电子书
 
-对于想收集起这些电子书以供日常翻阅的学习者，可单击此[链接](https://cloud.189.cn/t/mquiQvIZBRza)下载全部电子书。
+对于想收集起这些电子书以供日常翻阅的学习者，可单击此[链接](https://cloud.189.cn/t/mquiQvIZBRza)下载全部电子书 **（非当前展示的电子书，待更新）**。
 
 ## 2. 工具篇
 
@@ -133,6 +135,6 @@
 
 ## 6. 习惯篇
 
-- [电脑管理篇](https://www.zhihu.com/people/niu-dai-68-44/answers/by_votes) - 维护一个健康的电脑环境
+- [电脑管理篇](https://www.zhihu.com/question/265575756/answer/607419141) - 维护一个健康的电脑环境
 - [代码风格篇](doc/habits/habit_checkstyle.md) - 写出优雅代码
 - [视野篇](doc/habits/habit_know_how.md) - 获取更广视野

--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@
   - **简介**： 这本书简称 `CSAPP`，是所有计算机人士必看的一本「**内功心法**」，也是名校卡耐基·梅隆大学的计算机专业本科生的基础教程，常看常新，在海内外享誉无数。
   - **中文版**：[《深入理解计算机系统》](https://cloud.189.cn/t/iEn2MfQZVvMv) 第三版 (2016) 【`美版中译本` | `高清扫描版` | `彩色版`】
 
-- [Computer Networking: A Top-Down Approach](https://www.aliyundrive.com/s/zZvJzm9QN5U) 8th Edition (2021) 【`美版`】
-  - **简介**：这是计算机网络经典教材，采用自顶向下方法写作，适合大多数人。
-  - **中文版**：[《计算机网络：自顶向下方法》](https://cloud.189.cn/t/mIzY7rmiUnua) 第七版 (2018) 【`高清扫描版`】
-
-- [Computer Networks: A Systems Approach](https://www.aliyundrive.com/s/dyUZdoA3VNe) 6th Edition (2021) 【`美版`】
-  - **简介**：该书与《计算机网络：自顶向下方法》齐名，该书的顺序是自底向上，但是没有花费过多的笔墨介绍物理层。该书对于链路层、网络层、高级网络层、端到端（传输层）的介绍非常详细，可以有助于网络学习者快速建立全局观，而且可以避免沉迷在纷繁的应用层协议里无法自拔。推荐初学者先看这本书。
-  - **中文版**：[《计算机网络：系统方法》](https://cloud.189.cn/t/QbAbainaE3Yb) 第五版 (2015) 【`高清扫描版`】
-
 - [Compilers: Principles, Techniques, and Tools](https://www.aliyundrive.com/s/swx2pdvczph) 2nd Edition International Edition (2014) 【`国际版`】
   - **简介**：这就是大名鼎鼎的编译原理「恐龙书」或「龙书」，另有「虎书」、「鲸书」，但是三本书中唯有龙书最牛
   - **中文版**：[《编译原理》](https://cloud.189.cn/t/MNBzmynaaiAb) 【`美版中译本` | `高清扫描版`】
@@ -73,6 +65,18 @@
   - **简介**：这本书的作者是著名的计算机科学家 Tanenbaum，作者名字一般译为**塔嫩鲍姆**，他也是著名的 MINIX 系统的作者。Linux 内核的作者 Linus Torvalds 在他的自传 Just for Fun 里面这样评价塔嫩鲍姆的另一本书：**每个人都会遇到一本改变自己一生的书吧......而安德鲁·坦尼鲍姆所著的书《操作系统：设计与实现》让我脱胎换骨，达到了一个全新的高度，改变了我的一生。** 这本《现代操作系统》更具现代意义，算是 Linus 高度赞誉的那本书的新时代版本。如果你能把这本书通读一遍，相信你肯定可以升华自己的境界。
   - **中文版**：[《现代操作系统》](https://cloud.189.cn/t/fi2MJjMnUZFb) 第四版 (2017) 【`高清扫描版`】
 
+- [Computer Organization and Design RISC-V Edition The Hardware/Software Interface](https://www.aliyundrive.com/s/Rscs2rGkNhG) 2nd Edition (2021)【`美版`】
+  - **简介**：计算机组成与设计：硬件/软件接口系列的书是两位泰斗级人物： David A. Patterson 和 John L. Hennessy 合著的巨作，著名的《计算机体系结构：量化研究方法》也是他们的作品。
+  - **中文版**：[《计算机组成与设计：硬件/软件接口 MIPS版》](https://cloud.189.cn/t/INrQ7vnQnaum) 第五版 (2015) 【`高清扫描版`】
+
+- [Computer Networking: A Top-Down Approach](https://www.aliyundrive.com/s/zZvJzm9QN5U) 8th Edition (2021) 【`美版`】
+  - **简介**：这是计算机网络经典教材，采用自顶向下方法写作，适合大多数人。
+  - **中文版**：[《计算机网络：自顶向下方法》](https://cloud.189.cn/t/mIzY7rmiUnua) 第七版 (2018) 【`高清扫描版`】
+
+- [Computer Networks: A Systems Approach](https://www.aliyundrive.com/s/dyUZdoA3VNe) 6th Edition (2021) 【`美版`】
+  - **简介**：该书与《计算机网络：自顶向下方法》齐名，该书的顺序是自底向上，但是没有花费过多的笔墨介绍物理层。该书对于链路层、网络层、高级网络层、端到端（传输层）的介绍非常详细，可以有助于网络学习者快速建立全局观，而且可以避免沉迷在纷繁的应用层协议里无法自拔。推荐初学者先看这本书。
+  - **中文版**：[《计算机网络：系统方法》](https://cloud.189.cn/t/QbAbainaE3Yb) 第五版 (2015) 【`高清扫描版`】
+
 #### 1.2.3 算法基础
 
 - [Algorithms](https://cloud.189.cn/t/uIbQRbniQNrm) 4th Edition (2014) 【`美版`】
@@ -82,10 +86,6 @@
 - [Introduction to Algorithms](https://www.aliyundrive.com/s/J5T7n1Q94j9) 4th Edition (2022) 【`美版`】
   - **简介**：算法导论是算法学习者必备的一本书，内容深度、广度都很大，是进阶选手、基础比较高的学习者所必看的一本算法书。该书给出的都是伪代码，因此比较适合理解原理。
   - **中文版**：[《算法导论》](https://cloud.189.cn/t/iuqm2aVvemem) 第三版 (2012) 【`高清扫描版`】
-
-- [Computer Organization and Design RISC-V Edition The Hardware/Software Interface](https://www.aliyundrive.com/s/Rscs2rGkNhG) 2nd Edition (2021)【`美版`】
-  - **简介**：计算机组成与设计：硬件/软件接口系列的书是两位泰斗级人物： David A. Patterson 和 John L. Hennessy 合著的巨作，著名的《计算机体系结构：量化研究方法》也是他们的作品。
-  - **中文版**：[《计算机组成与设计：硬件/软件接口 MIPS版》](https://cloud.189.cn/t/INrQ7vnQnaum) 第五版 (2015) 【`高清扫描版`】
 
 #### 1.2.4 UNIX & Linux
 

--- a/README.md
+++ b/README.md
@@ -35,39 +35,37 @@
 
 #### 1.2.1 数学基础
 
-- [Discrete Mathematics and Its Applications](TODO) 8th Edition (2021) 【`美版`】
+- [Discrete Mathematics and Its Applications](https://www.aliyundrive.com/s/SANHYAD3hRh) 8th Edition (2021) 【`美版`】
   - **简介**：**离散数学**笼统地介绍了许多与计算机相关的数学领域，离散数学并不是「连续数学」即分析学的对立面，而是一个大杂烩，里面什么都有，排序、图论、自动机理论、编码、逻辑等等都被囊括其中。
   - **中文版**：[《离散数学及其应用》](https://cloud.189.cn/t/yUjaAjMNnqIf) 第七版 (2015) 【`高清扫描版`】
 
-- [Operations Research: An Introduction](https://cloud.189.cn/t/BR7FJvymEzIb) 10th Edition (2017) 【`国际版` | `黑白版`】
+- [Operations Research: An Introduction](https://www.aliyundrive.com/s/WDDoLBMX3aW) 10th Edition (2017) 【`国际版` | `黑白版`】
   - **简介**：运筹学是一个涉及过程优化的学问，在数学里是一个大的分支，网络流问题是该领域的研究核心，因为诸如指派、线性规划、整数规划、零一规划、拓扑图问题等，都可以全部或者部分地归为网络流问题。这个领域的问题以及结论非常多，建议非此专业的新手，把这门课当作算法课的补充与延伸，不要过于深入。
   - **中文版**：**暂无**
 
-- [Computational Complexity: A Modern Approach](TODO) (2009) 【`美版` | `黑白版`】
+- [Computational Complexity: A Modern Approach](https://www.aliyundrive.com/s/i11JZeSv8VN) (2009) 【`美版` | `黑白版`】
   - **简介**：可计算理论、计算复杂性理论应该是现代计算机的核心思想，这是阿兰·图灵和丘奇的开创性理论及拓展，学习本门课需要比较强的数学基础，但是这门课不一定是入门者必学的课，但是学了这门课之后，你会对计算机的原理将有更深刻的认视，比如 CPU 为什么需要寄存器，为什么有些问题是不可计算的，为什么计算安全性也能用于实际。由于本门课一般是研究生课程，而且实际应用中的作用不明显，所以不把这门课放在数学基础篇的开头。这本书的作者是著名的计算科学专家阿罗拉。
   - **中文版**：[《计算复杂性：现代方法》](https://cloud.189.cn/t/FnYZBnmANN3m) (2012) 【`高清扫描版`】
 
 #### 1.2.2 计算机基础
 
-- [Computer Systems: A Programmer's Perspective](TODO) 3rd Edition (2015) 【`国际版`】
+- [Computer Systems: A Programmer's Perspective](https://www.aliyundrive.com/s/cqm3zmGNwqs) 3rd Edition Global Edition (2015) 【`国际版`】
   - **简介**： 这本书简称 `CSAPP`，是所有计算机人士必看的一本「**内功心法**」，也是名校卡耐基·梅隆大学的计算机专业本科生的基础教程，常看常新，在海内外享誉无数。
   - **中文版**：[《深入理解计算机系统》](https://cloud.189.cn/t/iEn2MfQZVvMv) 第三版 (2016) 【`美版中译本` | `高清扫描版` | `彩色版`】
 
-- [Computer Networking: A Top-Down Approach](TODO) 8th Edition (2021) 【`美版`】
+- [Computer Networking: A Top-Down Approach](https://www.aliyundrive.com/s/zZvJzm9QN5U) 8th Edition (2021) 【`美版`】
   - **简介**：这是计算机网络经典教材，采用自顶向下方法写作，适合大多数人。
   - **中文版**：[《计算机网络：自顶向下方法》](https://cloud.189.cn/t/mIzY7rmiUnua) 第七版 (2018) 【`高清扫描版`】
 
-Compilers Principles, Techniques, and Tools
-
-- [Computer Networks: A Systems Approach](TODO) 6th Edition (2021) 【`美版`】
+- [Computer Networks: A Systems Approach](https://www.aliyundrive.com/s/dyUZdoA3VNe) 6th Edition (2021) 【`美版`】
   - **简介**：该书与《计算机网络：自顶向下方法》齐名，该书的顺序是自底向上，但是没有花费过多的笔墨介绍物理层。该书对于链路层、网络层、高级网络层、端到端（传输层）的介绍非常详细，可以有助于网络学习者快速建立全局观，而且可以避免沉迷在纷繁的应用层协议里无法自拔。推荐初学者先看这本书。
   - **中文版**：[《计算机网络：系统方法》](https://cloud.189.cn/t/QbAbainaE3Yb) 第五版 (2015) 【`高清扫描版`】
 
-- [Compilers: Principles, Techniques, and Tools](TODO) 2nd Edition (2014) 【`国际版`】
+- [Compilers: Principles, Techniques, and Tools](https://www.aliyundrive.com/s/swx2pdvczph) 2nd Edition International Edition (2014) 【`国际版`】
   - **简介**：这就是大名鼎鼎的编译原理「恐龙书」或「龙书」，另有「虎书」、「鲸书」，但是三本书中唯有龙书最牛
   - **中文版**：[《编译原理》](https://cloud.189.cn/t/MNBzmynaaiAb) 【`美版中译本` | `高清扫描版`】
 
-- [Operating System Concepts](TODO) 10th Edition (2018) 【`美版`】
+- [Operating System Concepts](https://www.aliyundrive.com/s/SCejGWuZsVQ) 10th Edition (2018) 【`美版`】
   - **简介**：操作系统有很多的经典教材，这本书是其中之一。但是这本书正如其名字所示，着重于概念，对于一些细节和举例，并不是很详细。
   - **中文版**：[《操作系统概念》](https://cloud.189.cn/t/ruqqArzUfqYb) 第九版 (2018) 【`高清扫描版`】
 
@@ -79,15 +77,15 @@ Compilers Principles, Techniques, and Tools
 
 - [Algorithms](https://cloud.189.cn/t/uIbQRbniQNrm) 4th Edition (2014) 【`美版`】
   - **简介**：这本就是大名鼎鼎的「**算法4**」，这本书起点比《算法导论》低，学起来更容易。
-  - **中文版**：[《算法》](TODO) 【`非扫描版` | `彩色版`】
+  - **中文版**：[《算法》](https://www.aliyundrive.com/s/1t9Y9uMTz4b) 第四版 【`非扫描版` | `彩色版`】
 
-- [Introduction to Algorithms](TODO) 4th Edition (2022) 【`美版`】
+- [Introduction to Algorithms](https://www.aliyundrive.com/s/J5T7n1Q94j9) 4th Edition (2022) 【`美版`】
   - **简介**：算法导论是算法学习者必备的一本书，内容深度、广度都很大，是进阶选手、基础比较高的学习者所必看的一本算法书。该书给出的都是伪代码，因此比较适合理解原理。
   - **中文版**：[《算法导论》](https://cloud.189.cn/t/iuqm2aVvemem) 第三版 (2012) 【`高清扫描版`】
 
-- [Computer Organization and Design: The Hardware/Software Interface](TODO) RISC-V Edition 2nd Edition (2021)【`美版`】
-  - **简介**：此系列的书是两位泰斗级人物： David A. Patterson 和 John L. Hennessy 合著的巨作，著名的《计算机体系结构：量化研究方法》也是他们的作品。
-  - **中文版**：[《计算机组成与设计：硬件/软件接口》](https://cloud.189.cn/t/INrQ7vnQnaum) MIPS 版 第五版 (2015) 【`高清扫描版`】
+- [Computer Organization and Design RISC-V Edition The Hardware/Software Interface](https://www.aliyundrive.com/s/Rscs2rGkNhG) 2nd Edition (2021)【`美版`】
+  - **简介**：计算机组成与设计：硬件/软件接口系列的书是两位泰斗级人物： David A. Patterson 和 John L. Hennessy 合著的巨作，著名的《计算机体系结构：量化研究方法》也是他们的作品。
+  - **中文版**：[《计算机组成与设计：硬件/软件接口 MIPS版》](https://cloud.189.cn/t/INrQ7vnQnaum) 第五版 (2015) 【`高清扫描版`】
 
 #### 1.2.4 UNIX & Linux
 
@@ -105,7 +103,7 @@ Compilers Principles, Techniques, and Tools
 
 #### 1.2.5 数据库
 
-- [Database System Concepts](TODO) 7th Edition (2020) 【`美版`】
+- [Database System Concepts](https://www.aliyundrive.com/s/MuXm747SyeP) 7th Edition (2020) 【`美版`】
   - **简介**: 《数据库系统概念》是国外的经典数据库教材，里面关于并发，事务，锁等有细致系统的讲解。
   - **中文版** [《数据库系统概念》](https://cloud.189.cn/t/b6vUFvmmyi2u) 第六版 (2012) 【`高清扫描版`】
 


### PR DESCRIPTION
变更：
1. 以阿里云盘链接更新原版教材
2. 替换 Wayne L. Winston's Operations Research: Applications And Algorithms 为 Hamdy A. Taha's Operations Research: An Introduction

优化：
1. 教材标签结构 原版教材分为两种：【`美版`】和【`国际版`】，标签均默认为【`非扫描版` | `有书签` | `彩色版`】，中文版教材默认标签为对应美版和国际版的翻译版，默认为【`扫描版` | `OCR` | `有书签` | `黑白版`】。

修复：
6. 习惯篇 电脑管理篇 超链接指向错误